### PR TITLE
fix fonts so it compiles on Linux

### DIFF
--- a/src/common.tex
+++ b/src/common.tex
@@ -5,8 +5,9 @@
 
 % fonts
 \usepackage{fontspec}
-\newfontfamily\comicsans{Comic Sans MS}
-\setsansfont{Helvetica}
+% Using Linux-compatible fonts
+\newfontfamily\comicsans{DejaVu Sans}
+\setsansfont{Liberation Sans}
 
 % font settings for default text
 \newcommand{\bodyfont}{\sffamily\bfseries\fontsize{12}{12}\selectfont}

--- a/src/fullpage/fullpage.tex
+++ b/src/fullpage/fullpage.tex
@@ -34,8 +34,9 @@
 \usepackage{amsfonts,amsmath}
 
 \usepackage{fontspec}
-\newfontfamily\comicsans{Comic Sans MS}
-\setsansfont{Helvetica}
+% Using Linux-compatible fonts
+\newfontfamily\comicsans{DejaVu Sans}
+\setsansfont{Liberation Sans}
 
 \renewcommand{\baselinestretch}{0.85}
 


### PR DESCRIPTION
Requirements needed installing for everything to work (on archlinux):
`pacman -S texlive-core texlive-latexextra texlive-fontsextra texlive-pictures ttf-dejavu ttf-liberation`